### PR TITLE
require conf.zig to hold user-specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /zig-cache
 /zig-out
 **.class
+src/conf.zig

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ To try out jaz for yourself, install jvm 16, then run the following commands:
 # Compiles Java source
 javac test/src/jaztest/*.java
 
+# Adds user path to javastd
+echo "pub const conf = .{.javastd_path = \"/path/to/javastd\"};" > src/conf.zig
+
 # Runs demo
 zig build run
 ```

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const primitives = @import("interpreter/primitives.zig");
 const Interpreter = @import("interpreter/Interpreter.zig");
 const ClassResolver = @import("interpreter/ClassResolver.zig");
+// In order to build, you first must create src/conf.zig with contents
+// `pub const conf = .{.javastd_path = "..."};`
+const conf = @import("conf.zig").conf;
 
 pub fn main() anyerror!void {
     const allocator = std.heap.page_allocator;
@@ -14,7 +17,7 @@ pub fn main() anyerror!void {
         // 2. Open `java.base.jmod` with a dearchiving tool
         // 3. Plop the content of `classes` (excluding module_info) into a new directory
         // 4. Set the string below to the path of that new directory
-        try std.fs.openDirAbsolute("C:/Programming/Garbo/javastd", .{ .access_sub_paths = true, .iterate = true }),
+        try std.fs.openDirAbsolute(conf.javastd_path, .{ .access_sub_paths = true, .iterate = true }),
     };
     var class_resolver = try ClassResolver.init(allocator, &classpath);
     var interpreter = Interpreter.init(allocator, &class_resolver);


### PR DESCRIPTION
- this allows users to pull and build the project without
  having to modify main.zig

I guess this is a draft.  Not sure how you might want to handle this.  One change might be to move the conf.zig file next to build.zig and add it as a package.  That along with making sure conf.zig exists in build.zig.  

I think the command `echo "pub const conf = .{.javastd_path = \"/path/to/javastd\"};" > src/conf.zig` works on windows but i may be wrong. 